### PR TITLE
emit gossip to at least Dlo peers, without exclusions

### DIFF
--- a/gossipsub.go
+++ b/gossipsub.go
@@ -1736,6 +1736,16 @@ func (gs *GossipSubRouter) emitGossip(topic string, exclude map[peer.ID]struct{}
 		}
 	}
 
+	if len(peers) < gs.params.Dlo {
+		for p := range gs.p.topics[topic] {
+			if gs.feature(GossipSubFeatureMesh, gs.peers[p]) {
+				peers = append(peers, p)
+			}
+			if len(peers) >= gs.params.Dlo {
+				break
+			}
+		}
+	}
 	target := gs.params.Dlazy
 	factor := int(gs.params.GossipFactor * float64(len(peers)))
 	if factor > target {


### PR DESCRIPTION
Modification to gossipsub protocol to allow emitting gossip to other nodes, when the number of nodes is very low in the network. Without this modification no gossip is emitted for the specific topic, if there are less than D nodes in the topic.
This allows receiving missed messages, in case of disconnections.